### PR TITLE
Features / Require authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 
 ## Docker compose: `docker compose up`
 
+> Note: in production, it's highly recommended to use `FORUM_BACKEND_SECRET` to secure private API endpoints.
+>
+> You can generate it using the following command:
+
+### Docker production: `FORUM_BACKEND_SECRET=$(uuidgen) docker compose up`
+
 ### Natively (dev)
 
 requirements: Node.js, Golang, GCC
 
-#### Script: `sh dev.sh`
-
 #### Commands:
 
-#### Backend: `cd backend && go run .`
+#### Backend: `cd backend && go run backend/forum`
 
 #### Frontend: `cd frontend && npm run dev`

--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ requirements: Node.js, Golang, GCC
 #### Backend: `cd backend && go run backend/forum`
 
 #### Frontend: `cd frontend && npm run dev`
+
+## Environment variables
+
+Frontend and backend have their own environment variables. Check their READMEs for more information.
+
+Here's the list of environment variables used by both:
+
+- `FORUM_BACKEND_SECRET` - optional, secret `Internal-Auth` header value to bypass authentication for private API
+  endpoints. If not set, private API endpoints will be available to anyone with `Internal-Auth` header set to any value.
+
+- `FORUM_IS_PRIVATE` - optional, default: `true`.
+  Makes all endpoints private by default. If set to `false`, some endpoints will be available to anyone (
+  like `/api/posts`).

--- a/backend/forum/README.md
+++ b/backend/forum/README.md
@@ -32,6 +32,9 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 > Note: you can easily generate secret with `uuidgen` command, like this: `FORUM_BACKEND_SECRET=$(uuidgen)`.
 > Make sure that this secret is shared with frontend.
 
+- `FORUM_IS_PRIVATE` - optional, default `true`. If `true`, all endpoints will require authentication (except
+  `/api/login` and `/api/signup`).
+
 - `FRONTEND_REVALIDATE_URL` - optional, url to revalidate Next.js pages in ISR mode. For
   example, `http://localhost:3000/api/revalidate`
 - `FRONTEND_REVALIDATE_TOKEN` - optional, token to revalidate Next.js pages in ISR mode if frontend `/api/` is public

--- a/backend/forum/README.md
+++ b/backend/forum/README.md
@@ -26,6 +26,12 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 
 ### Environment variables:
 
+- `FORUM_BACKEND_SECRET` - optional, secret header `Internal-Auth` value to access private API endpoints. By default,
+  all requests to private endpoints with `Internal-Auth` header will be accepted.
+
+> Note: you can easily generate secret with `uuidgen` command, like this: `FORUM_BACKEND_SECRET=$(uuidgen)`.
+> Make sure that this secret is shared with frontend.
+
 - `FRONTEND_REVALIDATE_URL` - optional, url to revalidate Next.js pages in ISR mode. For
   example, `http://localhost:3000/api/revalidate`
 - `FRONTEND_REVALIDATE_TOKEN` - optional, token to revalidate Next.js pages in ISR mode if frontend `/api/` is public

--- a/backend/forum/handlers/auth.go
+++ b/backend/forum/handlers/auth.go
@@ -235,6 +235,9 @@ func (h *Handlers) logout(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// getUserId checks if the user's token is valid and returns the user's id
+//
+// If the token is not valid, it will return -1 and add an empty cookie to the response
 func (h *Handlers) getUserId(w http.ResponseWriter, r *http.Request) int {
 	cookie, err := r.Cookie("forum-token")
 	if err != nil {

--- a/backend/forum/handlers/handlers.go
+++ b/backend/forum/handlers/handlers.go
@@ -6,7 +6,14 @@ import (
 	"database/sql"
 	"log"
 	"net/http"
+	"runtime/debug"
 	"strings"
+)
+
+type ctxKey int
+
+const (
+	userIdCtxKey ctxKey = iota
 )
 
 type Handlers struct {
@@ -23,36 +30,40 @@ func (h *Handlers) Handler() http.Handler {
 
 	var routes = []server.Route{
 		// method GET endpoints
+		server.NewRoute(http.MethodGet, `/api/users/(\d+)`, h.usersId),
+		server.NewRoute(http.MethodGet, `/api/users/(\d+)/posts`, h.usersIdPosts),
+		server.NewRoute(http.MethodGet, `/api/users`, h.usersAll),
+
+		server.NewRoute(http.MethodGet, `/api/posts`, h.posts),
+		server.NewRoute(http.MethodGet, `/api/posts/(\d+)`, h.postsId),
+
+		server.NewRoute(http.MethodGet, `/api/posts/(\d+)/comments`, h.postsIdComments),
+
+		server.NewRoute(http.MethodGet, `/api/posts/categories`, h.postsCategories),
+		server.NewRoute(http.MethodGet, `/api/posts/categories/([[:alnum:]]+)`, h.postsCategoriesName),
+
+		// method POST endpoints
+		server.NewRoute(http.MethodPost, `/api/login`, h.login),
+		server.NewRoute(http.MethodPost, `/api/signup`, h.signup),
+	}
+
+	var authRoutes = []server.Route{
+		// method GET endpoints
 		server.NewRoute(http.MethodGet, `/api/me`, h.me),
 
 		server.NewRoute(http.MethodGet, `/api/me/posts`, h.mePosts),
 		server.NewRoute(http.MethodGet, `/api/me/posts/liked`, h.mePostsLiked),
 
-		server.NewRoute(http.MethodGet, `/api/users`, h.usersAll),
-		server.NewRoute(http.MethodGet, `/api/users/(\d+)`, h.usersId),
-		server.NewRoute(http.MethodGet, `/api/users/(\d+)/posts`, h.usersIdPosts),
-
-		server.NewRoute(http.MethodGet, `/api/posts`, h.posts),
-		server.NewRoute(http.MethodGet, `/api/posts/(\d+)`, h.postsId),
-
 		server.NewRoute(http.MethodGet, `/api/posts/(\d+)/reaction`, h.postsIdReaction),
-		server.NewRoute(http.MethodGet, `/api/posts/(\d+)/comments`, h.postsIdComments),
 
 		server.NewRoute(http.MethodGet, `/api/posts/(\d+)/comment/(\d+)/reaction`, h.postsIdCommentIdReaction),
 
-		server.NewRoute(http.MethodGet, `/api/posts/categories`, h.postsCategories),
-		server.NewRoute(http.MethodGet, `/api/posts/categories/([[:alnum:]]+)`, h.postsCategoriesName),
-
-		server.NewRoute(http.MethodGet, `/api/internal/check-session`, h.checkSession),
-
 		// method POST endpoints
+		server.NewRoute(http.MethodPost, `/api/logout`, h.logout),
+
 		server.NewRoute(http.MethodPost, `/api/posts/create`, h.postsCreate),
 		server.NewRoute(http.MethodPost, `/api/posts/(\d+)/like`, h.postsIdLike),
 		server.NewRoute(http.MethodPost, `/api/posts/(\d+)/dislike`, h.postsIdDislike),
-
-		server.NewRoute(http.MethodPost, `/api/login`, h.login),
-		server.NewRoute(http.MethodPost, `/api/signup`, h.signup),
-		server.NewRoute(http.MethodPost, `/api/logout`, h.logout),
 
 		server.NewRoute(http.MethodPost, `/api/posts/(\d+)/comment`, h.postsIdCommentCreate),
 
@@ -60,34 +71,58 @@ func (h *Handlers) Handler() http.Handler {
 		server.NewRoute(http.MethodPost, `/api/posts/(\d+)/comment/(\d+)/dislike`, h.postsIdCommentIdDislike),
 	}
 
+	var internalRoutes = []server.Route{
+		server.NewRoute(http.MethodGet, `/api/internal/check-session`, h.checkSession),
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
-				log.Printf("ERROR %d. %v\n", http.StatusInternalServerError, err)
+				log.Printf("ERROR %d. %v\n%s", http.StatusInternalServerError, err, debug.Stack())
 				server.ErrorResponse(w, http.StatusInternalServerError) // 500 ERROR
 			}
 		}()
-		r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
 
-		var requestRoute server.Route
+		// remove trailing slash
+		r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
 
 		for _, route := range routes {
 			if route.Pattern.MatchString(r.URL.Path) {
-				requestRoute = route
-				break
+				if r.Method != route.Method {
+					server.ErrorResponse(w, http.StatusMethodNotAllowed)
+					return
+				}
+
+				route.Handler(w, r)
+				return
 			}
 		}
 
-		if requestRoute.Handler == nil {
-			server.ErrorResponse(w, http.StatusNotFound)
-			return
+		for _, route := range authRoutes {
+			if route.Pattern.MatchString(r.URL.Path) {
+				if r.Method != route.Method {
+					server.ErrorResponse(w, http.StatusMethodNotAllowed)
+					return
+				}
+
+				h.withAuth(route.Handler)(w, r)
+				return
+			}
 		}
 
-		if r.Method != requestRoute.Method {
-			server.ErrorResponse(w, http.StatusMethodNotAllowed)
-			return
+		for _, route := range internalRoutes {
+			if route.Pattern.MatchString(r.URL.Path) {
+				if r.Method != route.Method {
+					server.ErrorResponse(w, http.StatusMethodNotAllowed)
+					return
+				}
+
+				h.withInternal(route.Handler)(w, r)
+				return
+			}
 		}
 
-		requestRoute.Handler(w, r)
+		// if we're still here, no route was found
+		server.ErrorResponse(w, http.StatusNotFound)
 	})
 }

--- a/backend/forum/handlers/me.go
+++ b/backend/forum/handlers/me.go
@@ -7,11 +7,7 @@ import (
 
 // me returns the currently logged-in user's information.
 func (h *Handlers) me(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	user := h.DB.GetUserById(userId)
 
@@ -36,11 +32,7 @@ func (h *Handlers) me(w http.ResponseWriter, r *http.Request) {
 
 // mePosts returns the posts of the logged-in user.
 func (h *Handlers) mePosts(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	user := h.DB.GetUserById(userId)
 	posts := h.DB.GetUserPosts(userId)
@@ -71,11 +63,7 @@ func (h *Handlers) mePosts(w http.ResponseWriter, r *http.Request) {
 
 // mePostsLiked returns the posts liked by the logged-in user.
 func (h *Handlers) mePostsLiked(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	posts := h.DB.GetUserPostsLiked(userId)
 

--- a/backend/forum/handlers/middlewares.go
+++ b/backend/forum/handlers/middlewares.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"backend/common/server"
+	"context"
+	"net/http"
+	"os"
+)
+
+// withAuth is a middleware that checks if the user is authenticated
+func (h *Handlers) withAuth(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var userId int
+
+		if r.Header.Get("Internal-Auth") == "" {
+			userId = h.getUserId(w, r)
+			if userId == -1 {
+				server.ErrorResponse(w, http.StatusUnauthorized)
+				return
+			}
+		} else {
+			// Bypass auth if Internal-Auth header is set
+			if r.Header.Get("Internal-Auth") == os.Getenv("FORUM_BACKEND_SECRET") ||
+				os.Getenv("FORUM_BACKEND_SECRET") == "" {
+				userId = -1
+			} else {
+				server.ErrorResponse(w, http.StatusUnauthorized)
+				return
+			}
+		}
+
+		ctx := context.WithValue(r.Context(), userIdCtxKey, userId)
+		r = r.WithContext(ctx)
+
+		handler(w, r)
+	}
+}
+
+// withInternal is a middleware that checks if the request has the valid Internal-Auth header set
+func (h *Handlers) withInternal(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Internal-Auth") == "" {
+			server.ErrorResponse(w, http.StatusForbidden)
+			return
+		}
+
+		if r.Header.Get("Internal-Auth") == os.Getenv("FORUM_BACKEND_SECRET") ||
+			os.Getenv("FORUM_BACKEND_SECRET") == "" {
+			handler(w, r)
+		} else {
+			server.ErrorResponse(w, http.StatusUnauthorized)
+		}
+	}
+}

--- a/backend/forum/handlers/posts_create.go
+++ b/backend/forum/handlers/posts_create.go
@@ -23,11 +23,7 @@ const (
 
 // postsCreate creates a new post
 func (h *Handlers) postsCreate(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	requestBody := struct {
 		Title       string   `json:"title"`

--- a/backend/forum/handlers/posts_id.go
+++ b/backend/forum/handlers/posts_id.go
@@ -47,11 +47,7 @@ func (h *Handlers) postsId(w http.ResponseWriter, r *http.Request) {
 // returns current reaction
 func (h *Handlers) postsIdLike(w http.ResponseWriter, r *http.Request) {
 
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	postIdStr := strings.TrimPrefix(r.URL.Path, "/api/posts/")
 	postIdStr = strings.TrimSuffix(postIdStr, "/like")
@@ -98,11 +94,7 @@ func (h *Handlers) postsIdLike(w http.ResponseWriter, r *http.Request) {
 //
 // returns current reaction
 func (h *Handlers) postsIdDislike(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 	postIdStr := strings.TrimPrefix(r.URL.Path, "/api/posts/")
 	postIdStr = strings.TrimSuffix(postIdStr, "/dislike")
 	// /api/posts/1/dislike -> 1
@@ -146,11 +138,7 @@ func (h *Handlers) postsIdDislike(w http.ResponseWriter, r *http.Request) {
 
 // postsIdReaction returns the current reaction of the user to the post
 func (h *Handlers) postsIdReaction(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	postIdStr := strings.TrimPrefix(r.URL.Path, "/api/posts/")
 	postIdStr = strings.TrimSuffix(postIdStr, "/reaction")

--- a/backend/forum/handlers/posts_id_comment.go
+++ b/backend/forum/handlers/posts_id_comment.go
@@ -17,11 +17,7 @@ const (
 // postsIdCommentIdLike likes a comment on a specific post
 func (h *Handlers) postsIdCommentIdLike(w http.ResponseWriter, r *http.Request) {
 
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	commentId, err := strconv.Atoi(strings.Split(r.URL.Path, "/")[5])
 	// /api/posts/1/comment/2/like ->2
@@ -64,11 +60,7 @@ func (h *Handlers) postsIdCommentIdLike(w http.ResponseWriter, r *http.Request) 
 
 // postsIdCommentIdDislike dislikes a specific comment on a specific post
 func (h *Handlers) postsIdCommentIdDislike(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	commentId, err := strconv.Atoi(strings.Split(r.URL.Path, "/")[5])
 	if err != nil {
@@ -109,11 +101,7 @@ func (h *Handlers) postsIdCommentIdDislike(w http.ResponseWriter, r *http.Reques
 
 // postsIdCommentIdReactions returns SafeReaction with data about the reactions of a specific comment
 func (h *Handlers) postsIdCommentIdReaction(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	commentId, err := strconv.Atoi(strings.Split(r.URL.Path, "/")[5])
 	if err != nil {
@@ -138,11 +126,7 @@ func (h *Handlers) postsIdCommentIdReaction(w http.ResponseWriter, r *http.Reque
 
 // postsIdCommentCreate adds a comment on a specific post
 func (h *Handlers) postsIdCommentCreate(w http.ResponseWriter, r *http.Request) {
-	userId := h.getUserId(w, r)
-	if userId == -1 {
-		server.ErrorResponse(w, http.StatusUnauthorized)
-		return
-	}
+	userId := r.Context().Value(userIdCtxKey).(int)
 
 	postIdStr := strings.TrimPrefix(r.URL.Path, "/api/posts/")
 	postIdStr = strings.TrimSuffix(postIdStr, "/comment")

--- a/backend/forum/handlers/test/internal_test.go
+++ b/backend/forum/handlers/test/internal_test.go
@@ -4,6 +4,7 @@ import (
 	. "backend/forum/handlers/test/server"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
 	"testing"
 )
@@ -13,36 +14,103 @@ func TestCheckSession(t *testing.T) {
 	cli := testServer.TestClient()
 	cli.TestAuth(t)
 
-	type Error struct {
-		Error string `json:"error"`
-	}
+	t.Run("Invalid header", func(t *testing.T) {
+		// No header
+		cli.TestGet(t, "/api/internal/check-session", http.StatusForbidden)
 
-	cli.TestGet(t, "/api/internal/check-session", http.StatusBadRequest)
-
-	_, respBody := cli.TestGet(t, "/api/internal/check-session?token=invalid", http.StatusOK)
-	var errResp Error
-	err := json.Unmarshal(respBody, &errResp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if errResp.Error == "" {
-		t.Fatal("Expected error")
-	}
-
-	var token string
-	for _, cookie := range cli.Cookies {
-		if cookie.Name == "forum-token" {
-			token = cookie.Value
+		err := os.Setenv("FORUM_BACKEND_SECRET", "secret")
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
+		req := generateInternalRequest(t, testServer, "/api/internal/check-session")
+		err = os.Setenv("FORUM_BACKEND_SECRET", "secret has changed")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cli.TestRequest(t, req, http.StatusUnauthorized)
+	})
 
-	_, respBody = cli.TestGet(t, "/api/internal/check-session?token="+token, http.StatusOK)
-	userId, err := strconv.Atoi(string(respBody))
+	err := os.Setenv("FORUM_BACKEND_SECRET", "super secret not guessable token")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if userId != 1 {
-		t.Fatalf("Expected user id 1, got %d", userId)
+	t.Run("Invalid token", func(t *testing.T) {
+		req := generateInternalRequest(t, testServer, "/api/internal/check-session")
+		cli.TestRequest(t, req, http.StatusBadRequest)
+
+		req = generateInternalRequest(t, testServer, "/api/internal/check-session?token=invalid")
+		_, respBody := cli.TestRequest(t, req, http.StatusOK)
+
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		err = json.Unmarshal(respBody, &errResp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if errResp.Error == "" {
+			t.Fatal("Expected error")
+		}
+	})
+
+	t.Run("Invalid method", func(t *testing.T) {
+		req := generateInternalRequest(t, testServer, "/api/internal/check-session?token=invalid")
+		req.Method = http.MethodPost
+		cli.TestRequest(t, req, http.StatusMethodNotAllowed)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		var token string
+		for _, cookie := range cli.Cookies {
+			if cookie.Name == "forum-token" {
+				token = cookie.Value
+			}
+		}
+
+		_, respBody := cli.TestRequest(t,
+			generateInternalRequest(t, testServer, "/api/internal/check-session?token="+token),
+			http.StatusOK)
+		userId, err := strconv.Atoi(string(respBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if userId != 1 {
+			t.Fatalf("Expected user id 1, got %d", userId)
+		}
+	})
+}
+
+func TestBypassAuth(t *testing.T) {
+	testServer := NewTestServer(t)
+	cli := testServer.TestClient()
+
+	cli.TestGet(t, "/api/me", http.StatusUnauthorized)
+
+	err := os.Setenv("FORUM_BACKEND_SECRET", "super secret nobody knows")
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	req := generateInternalRequest(t, testServer, "/api/me")
+
+	cli.TestRequest(t, req, http.StatusInternalServerError)
+
+	err = os.Setenv("FORUM_BACKEND_SECRET", "secret has changed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.TestRequest(t, req, http.StatusUnauthorized)
+}
+
+func generateInternalRequest(t *testing.T, testServer TestServer, path string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, testServer.URL+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Internal-Auth", os.Getenv("FORUM_BACKEND_SECRET"))
+	return req
 }

--- a/backend/forum/handlers/test/posts_test.go
+++ b/backend/forum/handlers/test/posts_test.go
@@ -11,6 +11,11 @@ import (
 func TestPosts(t *testing.T) {
 	testServer := NewTestServer(t)
 
+	t.Run("Invalid method", func(t *testing.T) {
+		cli := testServer.TestClient()
+		cli.TestPost(t, "/api/posts", nil, http.StatusMethodNotAllowed)
+	})
+
 	t.Run("Initial", func(t *testing.T) {
 		cli := testServer.TestClient()
 

--- a/backend/forum/handlers/test/private_mode_test.go
+++ b/backend/forum/handlers/test/private_mode_test.go
@@ -1,0 +1,33 @@
+package server_test
+
+import (
+	. "backend/forum/handlers/test/server"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestPrivateMode(t *testing.T) {
+	testServer := NewTestServer(t)
+
+	cli := testServer.TestClient()
+
+	t.Run("Disabled", func(t *testing.T) {
+		cli.TestGet(t, "/api/posts/categories", http.StatusOK)
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		err := os.Setenv("FORUM_IS_PRIVATE", "true")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cli.TestGet(t, "/api/posts/categories", http.StatusUnauthorized)
+
+		err = os.Setenv("FORUM_IS_PRIVATE", "false")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cli.TestGet(t, "/api/posts/categories", http.StatusOK)
+	})
+
+}

--- a/backend/forum/main.go
+++ b/backend/forum/main.go
@@ -7,11 +7,16 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
 func main() {
 	log.SetFlags(log.Lshortfile)
+
+	if os.Getenv("FORUM_BACKEND_SECRET") == "" {
+		log.Println("WARNING: FORUM_BACKEND_SECRET is not set, any request with Internal-Auth header will be accepted")
+	}
 
 	port := flag.String("port", "8080", "specify server port")
 	dbFile := flag.String("db", "database.db", "specify custom database file path")

--- a/backend/forum/main.go
+++ b/backend/forum/main.go
@@ -18,6 +18,14 @@ func main() {
 		log.Println("WARNING: FORUM_BACKEND_SECRET is not set, any request with Internal-Auth header will be accepted")
 	}
 
+	if os.Getenv("FORUM_IS_PRIVATE") == "" {
+		err := os.Setenv("FORUM_IS_PRIVATE", "true")
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println("INFO: FORUM_IS_PRIVATE is not set, defaulting to true")
+	}
+
 	port := flag.String("port", "8080", "specify server port")
 	dbFile := flag.String("db", "database.db", "specify custom database file path")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: backend
     environment:
       - FRONTEND_REVALIDATE_URL=http://frontend:3000/api/revalidate
+      - FORUM_BACKEND_SECRET=${FORUM_BACKEND_SECRET}
     volumes:
       - db:/app/db
   frontend:
@@ -13,6 +14,7 @@ services:
     environment:
       - FORUM_BACKEND_PRIVATE_URL=http://backend:8080
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - FORUM_BACKEND_SECRET=${FORUM_BACKEND_SECRET}
     depends_on:
       - backend
     volumes:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,9 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 
 ### Environment variables
 
+- `FORUM_IS_PRIVATE` - optional, default: `true`.
+  Enables authentication middleware, redirects to login page if a user is not logged in.
+
 - `FORUM_BACKEND_PRIVATE_URL` - default for `dev`: `http://localhost:8080`.
   URL to [backend](../backend) instance to use for server-side rendering. Optional for building (to pre-render pages),
   but required for running.

--- a/frontend/src/api/posts/edge.ts
+++ b/frontend/src/api/posts/edge.ts
@@ -1,37 +1,61 @@
 import { Comment, Post } from "@/custom"
 
 export const getPostsLocal = (): Promise<Post[]> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })
 
 export const getPostLocal = (id: number): Promise<Post> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/${id}`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/${id}`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })
 
 export const getPostCommentsLocal = (id: number): Promise<Comment[]> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/${id}/comments`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/${id}/comments`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })
 
 export const getCategoriesLocal = (): Promise<string[]> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/categories`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/categories`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })
 
 export const getUserPostsLocal = (user_id: number): Promise<Post[]> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/users/${user_id}/posts`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/users/${user_id}/posts`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })
 
 export const getCategoryPostsLocal = (category: string): Promise<Post[]> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/categories/${category}`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/posts/categories/${category}`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })

--- a/frontend/src/api/users/edge.ts
+++ b/frontend/src/api/users/edge.ts
@@ -1,7 +1,11 @@
 import { User } from "@/custom"
 
 export const getUserLocal = (id: number): Promise<User> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/users/${id}`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/users/${id}`, {
+    headers: {
+      "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+    },
+  }).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })

--- a/frontend/src/app/api/next-public/ai/route.ts
+++ b/frontend/src/app/api/next-public/ai/route.ts
@@ -27,9 +27,17 @@ export const POST = async (req: Request) => {
   const response = await fetch(
     `${process.env.FORUM_BACKEND_PRIVATE_URL}/api/internal/check-session?token=${tokenCookie.value}`,
     {
+      headers: {
+        "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+      },
       cache: "no-cache",
     }
   )
+
+  if (!response.ok) {
+    return new Response("Temporarily unavailable", { status: 503 })
+  }
+
   const body = await response.json()
   if (body.error) {
     const cookie = serialize("forum-token", "", {

--- a/frontend/src/app/login/login-page.tsx
+++ b/frontend/src/app/login/login-page.tsx
@@ -42,7 +42,10 @@ const LoginPage = () => {
           setIsSame(true)
 
           logIn(login, password)
-            .then(() => mutate())
+            .then(() => {
+              router.refresh()
+              mutate()
+            })
             .catch((err) => setFormError(err.message))
         }}
       >

--- a/frontend/src/components/userInfo.tsx
+++ b/frontend/src/components/userInfo.tsx
@@ -52,7 +52,7 @@ const UserInfo = () => {
         onClick={() =>
           logOut()
             .then(() => {
-              router.push("/login")
+              router.refresh()
               mutate()
             })
             .catch(null)

--- a/frontend/src/components/userInfo.tsx
+++ b/frontend/src/components/userInfo.tsx
@@ -1,11 +1,15 @@
 "use client"
 
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 
 import { logOut, useMe } from "@/api/auth"
 
 const UserInfo = () => {
   const { isError, isLoading, isLoggedIn, user, mutate } = useMe()
+
+  const router = useRouter()
+
   if (isError || isLoading) {
     return null
   }
@@ -47,7 +51,10 @@ const UserInfo = () => {
         className={"clickable cursor-pointer m-auto"}
         onClick={() =>
           logOut()
-            .then(() => mutate())
+            .then(() => {
+              router.push("/login")
+              mutate()
+            })
             .catch(null)
         }
       >

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+
+export async function middleware(request: NextRequest) {
+  if (process.env.FORUM_IS_PRIVATE === "false") {
+    return NextResponse.next()
+  }
+
+  const token = request.cookies.get("forum-token")?.value
+
+  if (!token) {
+    // TODO: add query param to redirect back after login
+    return NextResponse.redirect(new URL("/login", request.url))
+  }
+
+  const response = await fetch(
+    `${process.env.FORUM_BACKEND_PRIVATE_URL}/api/internal/check-session?token=${token}`,
+    {
+      headers: {
+        "Internal-Auth": process.env.FORUM_BACKEND_SECRET || "secret",
+      },
+    }
+  )
+
+  const body = await response.json()
+  if (body.error) {
+    const resp = NextResponse.rewrite(new URL("/login", request.url))
+    resp.cookies.set("forum-token", "", { maxAge: 0 })
+    return resp
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - login (login page)
+     * - signup (signup page)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|login|signup).*)",
+  ],
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,10 +15,6 @@ http {
     location /api/next-public/ {
       proxy_pass http://frontend:3000;
     }
-
-    location /api/internal/ {
-      return 404;
-    }
   }
 }
 # TODO: maybe add "server started at" message;


### PR DESCRIPTION
Will be rebased when #57 will be merged. Resolves #23.

This pull request adds a new **private mode**, which makes all the endpoints (except `/api/login` and `/api/signup`) require authentication. This mode is enabled by default, but can be disabled by setting environment variable `FORUM_IS_PRIVATE` to `false`. 

This mode might be removed after passing `real-time-forum`, because `social-network` is allowed to be public. 

This mode is getting activated in `main.go`, so tests still test all endpoints like they are public. There's also a new `private_mode_test` file that tests if private mode works as expected.