### PR TITLE
Hotfix: Error 500 on user page

### DIFF
--- a/frontend/src/api/posts/edge.ts
+++ b/frontend/src/api/posts/edge.ts
@@ -25,7 +25,7 @@ export const getCategoriesLocal = (): Promise<string[]> =>
   })
 
 export const getUserPostsLocal = (user_id: number): Promise<Post[]> =>
-  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/user/${user_id}/posts`).then((res) => {
+  fetch(`${process.env.FORUM_BACKEND_PRIVATE_URL}/api/users/${user_id}/posts`).then((res) => {
     if (!res.ok) throw new Error("Network response was not ok")
     return res.json()
   })


### PR DESCRIPTION
In #62 we renamed user-related endpoints from `/api/user/...` to `/api/users/...`. 

But we forgot to replace it in one of the frontend functions. This caused error 500 on new user pages (users that were registered after patch). And broke the revalidation of the existing pages (already cached pages were unable to fetch new posts to show). 

We now have error 500 on https://forum-ci.mer.pw/user/20 and outdated list of posts on https://forum-ci.mer.pw/user/1. 

This fix replaces `/api/user` with `/api/users` in this function. 