### PR TITLE
Hotfix / Invalid `backend-chat` Docker image

### DIFF
--- a/.github/workflows/backend-docker-image.yml
+++ b/.github/workflows/backend-docker-image.yml
@@ -43,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: backend
+          build-args: SERVICE_NAME=${{ matrix.service }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -21,21 +21,25 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 
 ## Docker compose: `docker compose up`
 
+## Production:
+
 > Note: in production, it's highly recommended to use `FORUM_BACKEND_SECRET` to secure private API endpoints.
 >
-> You can generate it using the following command:
+> This can be done by generating a random string and passing it as an environment variable to docker compose:
+>
+> `FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker compose up`
 
-### Docker production: `FORUM_BACKEND_SECRET=$(uuidgen) docker compose up`
+### To run `main` branch version ([forum-ci.mer.pw](https://forum-ci.mer.pw))
+
+```shell
+FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker compose -f docker-compose.yml -f docker-compose.main.yml up
+```
 
 ### Natively (dev)
 
 requirements: Node.js, Golang, GCC
 
-#### Commands:
-
-#### Backend: `cd backend && go run backend/forum`
-
-#### Frontend: `cd frontend && npm run dev`
+Check frontend and backend READMEs for more information.
 
 ## Environment variables
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS builder
 
-ARG SERVICE_NAME=forum
+ARG SERVICE_NAME
 
 # install gcc, required by sqlite3 driver
 RUN apk add build-base

--- a/docker-compose.main.yml
+++ b/docker-compose.main.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  backend-forum:
+    image: ghcr.io/merpw/forum/backend-forum:main
+  backend-chat:
+    image: ghcr.io/merpw/forum/backend-chat:main
+  frontend:
+    image: ghcr.io/merpw/forum/frontend:main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
         - SERVICE_NAME=chat
     environment:
       - AUTH_BASE_URL=http://backend-forum:8080
+      - FORUM_BACKEND_SECRET=${FORUM_BACKEND_SECRET}
     volumes:
       - db:/app/db
     depends_on:


### PR DESCRIPTION
This pull request fixes the bug found while deploying the new `chat` service. This bug broke `backend-chat` docker image.

In #61 I've added a new service `backend-chat`. To build this new service as a separate docker image I've added a new build argument `SERVICE_NAME` to our `backend/Dockerfile`. To still be able to run `docker build -t backend` without specifying `SERVICE_NAME` I've used `forum` as a default value. Looks like it was a mistake :(

To automatically build this new docker image I've also updated our workflow. The problem was that I forgot to specify `SERVICE_NAME`, so both `backend-forum` and `backend-chat` images used the default value `forum` and became the same, so we had a second `forum` instead of `chat`. 

I've added this argument and removed the default value to show error in such cases. 

I've also built it in my private repo for testing and temporarily deployed to `forum-ci.mer.pw/ws`. It works well now. 

![image](https://github.com/merpw/forum/assets/43277901/0b7582ed-a074-443a-ba3e-dd112fc76329)
