### PR TITLE
Hotfix / Chat concurrency panic

### DIFF
--- a/backend/chat/handlers/chat_all.go
+++ b/backend/chat/handlers/chat_all.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"backend/chat/ws"
-	"log"
 )
 
 // chatAll returns a slice of all user's chats.
@@ -10,9 +9,5 @@ func (h *Handlers) chatAll(message ws.Message, client *ws.Client) {
 	chats := h.DB.GetUserChats(client.UserId)
 	responseMessage := ws.BuildResponseMessage(message, chats)
 
-	err := client.Conn.WriteJSON(responseMessage)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	h.Hub.Broadcast(responseMessage, client.UserId)
 }

--- a/backend/chat/handlers/chat_id.go
+++ b/backend/chat/handlers/chat_id.go
@@ -25,7 +25,7 @@ func (h *Handlers) chatId(message ws.Message, client *ws.Client) {
 
 	isMember := h.DB.IsChatMember(chatId, client.UserId)
 	if !isMember {
-		_ = client.Conn.WriteJSON(ws.BuildResponseMessage(message, nil))
+		h.Hub.Broadcast(ws.BuildResponseMessage(message, nil), client.UserId)
 		return
 	}
 
@@ -38,11 +38,7 @@ func (h *Handlers) chatId(message ws.Message, client *ws.Client) {
 	}
 	responseMessage := ws.BuildResponseMessage(message, responseData)
 
-	err = client.Conn.WriteJSON(responseMessage)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	h.Hub.Broadcast(responseMessage, client.UserId)
 }
 
 // chatIdMessages responds with all messages from a chat
@@ -58,13 +54,13 @@ func (h *Handlers) chatIdMessages(message ws.Message, client *ws.Client) {
 
 	isMember := h.DB.IsChatMember(chatId, client.UserId)
 	if !isMember {
-		_ = client.Conn.WriteJSON(ws.BuildResponseMessage(message, nil))
+		h.Hub.Broadcast(ws.BuildResponseMessage(message, nil), client.UserId)
 		return
 	}
 
 	chats := h.DB.GetChatMessages(chatId)
 	responseMessage := ws.BuildResponseMessage(message, chats)
-	err = client.Conn.WriteJSON(responseMessage)
+	h.Hub.Broadcast(responseMessage, client.UserId)
 	if err != nil {
 		log.Println(err)
 		return

--- a/backend/chat/handlers/chat_id_message.go
+++ b/backend/chat/handlers/chat_id_message.go
@@ -24,7 +24,7 @@ func (h *Handlers) chatIdMessage(message ws.Message, client *ws.Client) {
 
 	isMember := h.DB.IsChatMember(chatId, client.UserId)
 	if !isMember {
-		_ = client.Conn.WriteJSON(ws.BuildResponseMessage(message, nil))
+		h.Hub.Broadcast(ws.BuildResponseMessage(message, nil), client.UserId)
 		return
 	}
 

--- a/backend/chat/handlers/handshake.go
+++ b/backend/chat/handlers/handshake.go
@@ -4,7 +4,6 @@ import (
 	"backend/chat/external"
 	"backend/chat/ws"
 	"encoding/json"
-	"fmt"
 	"log"
 )
 
@@ -41,10 +40,27 @@ func (h *Handlers) handshake(messageBody []byte, client *ws.Client) {
 	client.UserId = userId
 	client.Token = message.Item.Token
 
-	err = client.Conn.WriteMessage(1, []byte(fmt.Sprintf(`{"type":"handshake","item":{"data":{"userId":%d}}}`, userId)))
-	if err != nil {
-		log.Println(err)
-	}
+	h.Hub.Broadcast(struct {
+		Type string `json:"type"`
+		Item struct {
+			Data struct {
+				UserId int `json:"userId"`
+			}
+		}
+	}{
+		Type: "handshake",
+		Item: struct {
+			Data struct {
+				UserId int `json:"userId"`
+			}
+		}{
+			Data: struct {
+				UserId int `json:"userId"`
+			}{
+				UserId: userId,
+			},
+		},
+	}, client.UserId)
 
 	h.Hub.BroadcastOnlineStatus()
 }

--- a/backend/chat/handlers/message_id.go
+++ b/backend/chat/handlers/message_id.go
@@ -20,7 +20,7 @@ func (h *Handlers) messageId(message ws.Message, client *ws.Client) {
 	msg := h.DB.GetMessage(messageId)
 
 	if !h.DB.IsChatMember(msg.ChatId, client.UserId) {
-		_ = client.Conn.WriteJSON(ws.BuildResponseMessage(message, nil))
+		h.Hub.Broadcast(ws.BuildResponseMessage(message, nil), client.UserId)
 		return
 	}
 
@@ -40,9 +40,5 @@ func (h *Handlers) messageId(message ws.Message, client *ws.Client) {
 		Timestamp: msg.Time,
 	})
 
-	err = client.Conn.WriteJSON(responseMessage)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	h.Hub.Broadcast(responseMessage, client.UserId)
 }

--- a/backend/chat/handlers/users_id.go
+++ b/backend/chat/handlers/users_id.go
@@ -27,9 +27,5 @@ func (h *Handlers) usersIdChat(message ws.Message, client *ws.Client) {
 
 	responseMessage := ws.BuildResponseMessage(message, data)
 
-	err = client.Conn.WriteJSON(responseMessage)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	h.Hub.Broadcast(responseMessage, client.UserId)
 }

--- a/backend/chat/handlers/users_online.go
+++ b/backend/chat/handlers/users_online.go
@@ -6,8 +6,5 @@ func (h *Handlers) usersOnline(message ws.Message, client *ws.Client) {
 	users := h.Hub.GetOnlineUsers()
 	responseMessage := ws.BuildResponseMessage(message, users)
 
-	err := client.Conn.WriteJSON(responseMessage)
-	if err != nil {
-		return
-	}
+	h.Hub.Broadcast(responseMessage, client.UserId)
 }

--- a/backend/chat/ws/ws.go
+++ b/backend/chat/ws/ws.go
@@ -103,6 +103,9 @@ func (h *Hub) Unregister(client *Client) {
 //
 // If no clients specified, sends to all
 func (h *Hub) Broadcast(data interface{}, clients ...int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if clients == nil {
 		// not specified, send to all
 		for _, c := range h.Clients {

--- a/backend/chat/ws/ws.go
+++ b/backend/chat/ws/ws.go
@@ -56,6 +56,12 @@ var wsUpgrader = websocket.Upgrader{
 
 // UpgradeHandler upgrades HTTP connection to WebSocket
 func (h *Hub) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Println("ERROR 500: ", err)
+		}
+	}()
+
 	conn, err := wsUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Fixes the elusive bug in chat service which causes a panic on production. 

Improves panic recovering by adding recover to the `UpgradeHandler`. We have already handled panics inside WebSocket message handlers, but panics outside them were not handled (such as the following one, which happened on user disconnection). 

```logs
forum-ci-backend-chat  | panic: concurrent write to websocket connection
forum-ci-backend-chat  |
forum-ci-backend-chat  | goroutine 1113 [running]:
forum-ci-backend-chat  | github.com/gorilla/websocket.(*messageWriter).flushFrame(0xc0001a0de0, 0x1, {0x0?, 0x7fa7d9afe288?, 0x7fa800f10108?})
forum-ci-backend-chat  |        /go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:617 +0x52b
forum-ci-backend-chat  | github.com/gorilla/websocket.(*messageWriter).Close(0xc0001a0e10?)
forum-ci-backend-chat  |        /go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:731 +0x45
forum-ci-backend-chat  | github.com/gorilla/websocket.(*Conn).beginMessage(0xc00010c000, 0xc0001a0e10, 0x1)
forum-ci-backend-chat  |        /go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:480 +0x42
forum-ci-backend-chat  | github.com/gorilla/websocket.(*Conn).NextWriter(0xc00010c000, 0x1)
forum-ci-backend-chat  |        /go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:520 +0x45
forum-ci-backend-chat  | github.com/gorilla/websocket.(*Conn).WriteJSON(0x7fa800f10108?, {0x8a2260, 0xc00019eac0})
forum-ci-backend-chat  |        /go/pkg/mod/github.com/gorilla/websocket@v1.5.0/json.go:24 +0x45
forum-ci-backend-chat  | backend/chat/ws.(*Hub).Broadcast(0x8a2260?, {0x8a2260, 0xc00019eac0}, {0x0?, 0x0?, 0x0?})
forum-ci-backend-chat  |        /app/chat/ws/ws.go:112 +0x85
forum-ci-backend-chat  | backend/chat/ws.(*Hub).BroadcastOnlineStatus(0xc0000793e0, {0x0, 0x0, 0x0})
forum-ci-backend-chat  |        /app/chat/ws/ws.go:144 +0x1fa
forum-ci-backend-chat  | backend/chat/ws.(*Hub).Unregister(0xc0000793e0, 0xc0000793b0?)
forum-ci-backend-chat  |        /app/chat/ws/ws.go:100 +0x1f5
forum-ci-backend-chat  | backend/chat/ws.(*Hub).UpgradeHandler.func1()
forum-ci-backend-chat  |        /app/chat/ws/ws.go:72 +0x3e
forum-ci-backend-chat  | created by backend/chat/ws.(*Hub).UpgradeHandler
forum-ci-backend-chat  |        /app/chat/ws/ws.go:70 +0x18d
```

In this case, one of the users has logged out, so the `BroadcastOnlineStatus` was called to notify all other users about it. But at the same time another user called another function (such as `send message`), so the connection was used by two goroutines at the same time.

The problem was in that [Gorilla WebSocket connections support only one concurrent reader and writer](https://pkg.go.dev/github.com/gorilla/websocket#hdr-Concurrency). We did not take it into account and called `WriteJSON` in several places without mutex protection. This pull request adds the mutex protection to the `Broadcast` function and replaces all direct calls of `WriteJSON` with concurrent-safe `Broadcast`.

This bug is elusive because we could not reproduce it locally. It should happen when there're two users do something at the same time, but even after sending thousands of messages and connecting/disconnecting at the same time, the service was still stable. 