### PR TITLE
Add `./start.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 
 ## How to run?
 
-## Docker compose: `docker compose up`
+## Run `./start.sh`
+
+Docker v3.4+ is required.
 
 ## Production:
+
+## Run `./start.sh`
+
+or `cd production && docker-compose up`
 
 > Note: in production, it's highly recommended to use `FORUM_BACKEND_SECRET` to secure private API endpoints.
 >
@@ -29,11 +35,27 @@ Solved during studying in Gritlab coding school on Åland, January 2023
 >
 > `FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker compose up`
 
-### To run `main` branch version ([forum-ci.mer.pw](https://forum-ci.mer.pw))
+### Other revisions: `./start.sh <revision>`
+
+To run `main` branch version ([forum-ci.mer.pw](https://forum-ci.mer.pw))
 
 ```shell
-FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker compose -f docker-compose.yml -f docker-compose.main.yml up
+./start.sh main
 ```
+
+To run `pr-76` revision
+
+```shell
+./start.sh pr-76
+```
+
+To build and run local revision
+
+```shell
+./start.sh local
+```
+
+> Note: if there's no such revision for one of the services, the default `main` revision will be used.
 
 ### Natively (dev)
 

--- a/docker-compose.main.yml
+++ b/docker-compose.main.yml
@@ -1,8 +1,0 @@
-version: "3"
-services:
-  backend-forum:
-    image: ghcr.io/merpw/forum/backend-forum:main
-  backend-chat:
-    image: ghcr.io/merpw/forum/backend-chat:main
-  frontend:
-    image: ghcr.io/merpw/forum/frontend:main

--- a/docker-compose.tag.yml
+++ b/docker-compose.tag.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  backend-forum:
+    image: ghcr.io/merpw/forum/backend-forum:${FORUM_TAG-main}
+  backend-chat:
+    image: ghcr.io/merpw/forum/backend-chat:${CHAT_TAG-main}
+  frontend:
+    image: ghcr.io/merpw/forum/frontend:${FRONTEND_TAG-main}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - FORUM_BACKEND_SECRET=${FORUM_BACKEND_SECRET}
     volumes:
       - db:/app/db
+    platform: linux/amd64
   backend-chat:
     build:
       context: backend
@@ -22,6 +23,7 @@ services:
       - db:/app/db
     depends_on:
       - backend-forum
+    platform: linux/amd64
   frontend:
     build:
       context: frontend
@@ -33,6 +35,7 @@ services:
       - backend-forum
     volumes:
       - cache:/app/.next/cache
+    platform: linux/amd64
   nginx:
     image: nginx:1.17.8-alpine
     volumes:

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3"
+name: "forum-prod"
+services:
+  backend:
+    image: ghcr.io/merpw/forum/backend:latest
+    container_name: forum-backend
+    volumes:
+      - "db:/app/db"
+    command: "server -db /app/db/database.db"
+  frontend:
+    image: ghcr.io/merpw/forum/frontend:latest
+    container_name: forum-frontend
+    environment:
+      - FORUM_BACKEND_PRIVATE_URL=http://backend:8080
+    depends_on:
+      - backend
+  nginx:
+    image: nginx:1.17.8-alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+      - frontend
+volumes:
+  db:
+    external: false
+  pages:
+    external: false

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - "db:/app/db"
     command: "server -db /app/db/database.db"
+    platform: linux/amd64
   frontend:
     image: ghcr.io/merpw/forum/frontend:latest
     container_name: forum-frontend
@@ -14,6 +15,7 @@ services:
       - FORUM_BACKEND_PRIVATE_URL=http://backend:8080
     depends_on:
       - backend
+    platform: linux/amd64
   nginx:
     image: nginx:1.17.8-alpine
     volumes:

--- a/production/nginx.conf
+++ b/production/nginx.conf
@@ -1,0 +1,15 @@
+events {}
+http {
+  server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+      proxy_pass http://frontend:3000;
+    }
+
+    location /api/ {
+      proxy_pass http://backend:8080;
+    }
+  }
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+TAG=${1:-"latest"}
+
+if [ "$TAG" == "latest" ]; then
+    echo "Starting latest revision"
+    cd production && FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker compose up;
+    return
+fi;
+
+if [ "$TAG" == "local" ]; then
+    echo "Starting build from local files"
+    FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker compose up;
+    return
+fi;
+
+if [ "$TAG" == "main" ]; then
+    echo "Starting main revision"
+    FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker-compose -f docker-compose.yml -f docker-compose.tag.yml up;
+    return
+fi;
+
+# Other revisions, e.g. pr-76. Use `main` tag if the revision doesn't exist
+exists () {
+    docker pull ghcr.io/merpw/forum/$1 >&2 2>&1
+}
+tagOrMain () {
+    echo "Checking if $1:$TAG exists" >&2
+    if exists "$1:$TAG"; then
+        echo $TAG
+    else
+        echo "main"
+    fi
+}
+
+export FORUM_TAG=$(tagOrMain "backend-forum")
+export CHAT_TAG=$(tagOrMain "backend-chat")
+export FRONTEND_TAG=$(tagOrMain "frontend")
+
+echo "Starting forum-backend:$FORUM_TAG, chat-backend:$CHAT_TAG, frontend:$FRONTEND_TAG"
+
+TAG=$TAG FORUM_BACKEND_SECRET=$(openssl rand -hex 32) docker-compose -f docker-compose.yml -f docker-compose.tag.yml up;


### PR DESCRIPTION
This pull request adds a new `./start.sh` script, which makes starting the project even easier than `docker compose`.

Instead of building the whole project every time, it's now possible to just pull a specific revision of Docker images from the GitHub Container Registry.

For example, to run the `latest` revision (the one that is deployed to https://forum.mer.pw), we can now just call:

```bash
./start.sh
```

Another important update is that the pull request review process was significantly simplified. When one opens a pull request, the docker image is built. We did not use this image before, but now we do!

```
./start.sh pr-76
```

E.g. this simple command starts the docker compose with images that were built in pull request 76. It’s much faster and easier than building all the services locally.
