### PR TITLE
Fix bug with invalid token authentication in the middleware

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -14,11 +14,14 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL("/login", request.url))
   }
 
-  checkSession(token).catch(() => {
-    const resp = NextResponse.rewrite(new URL("/login", request.url))
+  try {
+    await checkSession(token)
+  } catch (error) {
+    console.error("check session error", error)
+    const resp = NextResponse.redirect(new URL("/login", request.url))
     resp.cookies.set("forum-token", "", { maxAge: 0 })
     return resp
-  })
+  }
 
   return NextResponse.next()
 }


### PR DESCRIPTION
This pull request fixes the bug found while reviewing #76, which was hard to reproduce and was ignored.

In that pull request the `/api/internal/check-session` request was moved to the separate function `checkSession`. 

The mistake was to use `.catch()` instead of `try...catch` when using this function:

```ts
  checkSession(token).catch(() => {
    const resp = NextResponse.rewrite(new URL("/login", request.url))
    resp.cookies.set("forum-token", "", { maxAge: 0 })

    // this return returns the nested function inside catch, and not the parent one
    return resp
  })

  // we're still here, because the parent function still had no returns 
  return NextResponse.next()
```

This caused problems when token is not empty, but invalid, e.g. when running `localhost:3000` and `localhost` at the same time . `localhost` uses the cookie that was generated by another instance of backend connected to `localhost:3000`:

https://github.com/merpw/forum/assets/43277901/656ed536-9b87-45eb-a47f-8b14d88eac4b

It was really hard to reproduce because even when the page loads, the first `/me` and `.../reaction` direct backend requests clean the invalid cookie, so the further requests are successfully blocked by middleware as there's no token at all. 

This pull request replaces `.catch()` with `try..catch` to return the right function.