### PR TITLE
Features / Improve chat scrolling

### DIFF
--- a/frontend/src/api/chats/messages.ts
+++ b/frontend/src/api/chats/messages.ts
@@ -33,17 +33,17 @@ export const useMessages = (messageIds: number[]) => {
   const allMessages = useAppSelector((state) => state.chats.messages)
 
   const messages = useMemo(() => {
-    return messageIds.map((id) => allMessages?.[id]).filter(Boolean)
+    return messageIds.map((id) => allMessages?.[id])
   }, [allMessages, messageIds])
 
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    messageIds
-      .filter((id) => !allMessages?.[id])
-      .forEach((id) => {
+    messageIds.forEach((id) => {
+      if (!allMessages?.[id]) {
         dispatch(wsActions.sendGet(`/message/${id}`))
-      })
+      }
+    })
   }, [dispatch, messageIds, allMessages])
 
   return { messages }

--- a/frontend/src/components/chats/ChatMessages.tsx
+++ b/frontend/src/components/chats/ChatMessages.tsx
@@ -37,10 +37,26 @@ const ChatMessages: FC<{ chatId: number }> = ({ chatId }) => {
 
   const [hasUnread, setHasUnread] = useState(false)
 
+  const showStickyDateTimeout = useRef<NodeJS.Timeout | null>(null)
+  const [showStickyDate, setShowStickyDate] = useState(false)
+
   const onScroll = throttle(() => {
     if (!scrollRef.current) {
       return
     }
+
+    if (!showStickyDate) {
+      setShowStickyDate(true)
+    }
+
+    if (showStickyDateTimeout.current) {
+      clearTimeout(showStickyDateTimeout.current)
+    }
+    showStickyDateTimeout.current = setTimeout(() => {
+      if (showStickyDate) {
+        setShowStickyDate(false)
+      }
+    }, 1000)
 
     isOnBottom.current =
       scrollRef.current.scrollHeight -
@@ -105,7 +121,7 @@ const ChatMessages: FC<{ chatId: number }> = ({ chatId }) => {
   return (
     <div ref={scrollRef} onScroll={onScroll} className={"overflow-y-auto"}>
       <div ref={observerRef}>
-        <MessageGroups messageIds={messages} />
+        <MessageGroups messageIds={messages} showStickyDate={showStickyDate} />
       </div>
     </div>
   )

--- a/frontend/src/components/chats/Message.tsx
+++ b/frontend/src/components/chats/Message.tsx
@@ -1,15 +1,13 @@
-import { FC, useRef } from "react"
+import { FC, memo, useEffect, useState } from "react"
 import dayjs from "dayjs"
 
 import { useMe } from "@/api/auth/hooks"
 import { useMessage } from "@/api/chats/messages"
-import Markdown from "@/components/markdown/markdown"
+import RenderMarkdown from "@/components/markdown/render"
+import { Message as MessageType } from "@/ws"
 
 const Message: FC<{ id: number }> = ({ id }) => {
-  const { user } = useMe()
   const { message } = useMessage(id)
-
-  const ref = useRef<HTMLDivElement>(null)
 
   if (!message) {
     return null
@@ -25,31 +23,49 @@ const Message: FC<{ id: number }> = ({ id }) => {
           {message.content} at {dayjs(message.timestamp).format("HH:mm")}
         </span>
       ) : (
-        <div
-          ref={ref}
-          className={
-            "py-1 px-3 rounded w-fit flex flex-wrap max-w-[85%]" +
-            " " +
-            (user?.id !== message.authorId
-              ? "rounded-bl-none dark:bg-gray-800 bg-blue-200 mr-auto justify-end"
-              : "rounded-br-none dark:bg-gray-900 bg-gray-200 ml-auto justify-end")
-          }
-        >
-          <Markdown
-            className={"prose-img:max-h-[50vh]"}
-            content={message.content}
-            fallback={message.content}
-          />
-          <span
-            className={"ml-2 mt-auto text-sm opacity-75"}
-            title={dayjs(message.timestamp).format("YYYY-MM-DD HH:mm:ss")}
-          >
-            {dayjs(message.timestamp).format("HH:mm")}
-          </span>
-        </div>
+        <MarkdownMessage message={message} />
       )}
     </>
   )
 }
 
-export default Message
+const MarkdownMessage: FC<{ message: MessageType }> = ({ message }) => {
+  const [html, setHtml] = useState<string>()
+
+  const { user } = useMe()
+
+  useEffect(() => {
+    RenderMarkdown(message.content).then((html) => {
+      setHtml(html)
+    })
+  })
+
+  if (!html) {
+    return null
+  }
+
+  return (
+    <div
+      className={
+        "py-1 px-3 rounded w-fit flex flex-wrap max-w-[85%]" +
+        " " +
+        (user?.id !== message.authorId
+          ? "rounded-bl-none dark:bg-gray-800 bg-blue-200 mr-auto justify-end"
+          : "rounded-br-none dark:bg-gray-900 bg-gray-200 ml-auto justify-end")
+      }
+    >
+      <div
+        className={"prose dark:prose-invert max-w-full prose-img:max-h-[50vh]"}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <span
+        className={"ml-2 mt-auto text-sm opacity-75"}
+        title={dayjs(message.timestamp).format("YYYY-MM-DD HH:mm:ss")}
+      >
+        {dayjs(message.timestamp).format("HH:mm")}
+      </span>
+    </div>
+  )
+}
+
+export default memo(Message)

--- a/frontend/src/components/chats/MessagesDateGroups.tsx
+++ b/frontend/src/components/chats/MessagesDateGroups.tsx
@@ -8,7 +8,13 @@ const MessagesDateGroups: FC<{ messageIds: number[]; showStickyDate: boolean }> 
   messageIds,
   showStickyDate,
 }) => {
+  // load the most recent messages first
+  messageIds.reverse()
+
   const { messages } = useMessages(messageIds)
+
+  // reverse back to original order
+  messages.reverse()
 
   const { groupedMessages, processingMessages } = useMemo(() => {
     const groupedMessages = messages.reduce((acc, message) => {

--- a/frontend/src/components/chats/MessagesDateGroups.tsx
+++ b/frontend/src/components/chats/MessagesDateGroups.tsx
@@ -4,28 +4,34 @@ import dayjs from "dayjs"
 import { useMessages } from "@/api/chats/messages"
 import Message from "@/components/chats/Message"
 
-const MessagesDateGroups: FC<{ messageIds: number[] }> = ({ messageIds }) => {
+const MessagesDateGroups: FC<{ messageIds: number[]; showStickyDate: boolean }> = ({
+  messageIds,
+}) => {
   const { messages } = useMessages(messageIds)
 
-  const groupedMessages = useMemo(
-    () =>
-      messages.reduce((acc, message) => {
-        if (!message) {
-          return acc
-        }
-        const date = dayjs(message.timestamp).format("YYYY-MM-DD")
-        if (!acc[date]) {
-          acc[date] = []
-        }
-        acc[date].push(message.id)
+  const { groupedMessages, processingMessages } = useMemo(() => {
+    const groupedMessages = messages.reduce((acc, message) => {
+      if (!message) {
         return acc
-      }, {} as Record<string, number[]>),
-    [messages]
-  )
+      }
+      const date = dayjs(message.timestamp).format("YYYY-MM-DD")
+      if (!acc[date]) {
+        acc[date] = []
+      }
+      acc[date].push(message.id)
+      return acc
+    }, {} as Record<string, number[]>)
+
+    const processingMessages = messages.filter((message) => !message)
+
+    return { groupedMessages, processingMessages }
+  }, [messages])
+
+  const groups = Object.entries(groupedMessages)
 
   return (
     <>
-      {Object.entries(groupedMessages).map(([date, messages]) => (
+      {groups.map(([date, messages], key) => (
         <div key={date} className={"relative flex flex-col gap-1.5 items-center"}>
           <div
             className={
@@ -34,6 +40,11 @@ const MessagesDateGroups: FC<{ messageIds: number[] }> = ({ messageIds }) => {
           >
             {formatDate(date)}
           </div>
+          {key === 0 &&
+            processingMessages.map((_, key) => {
+              // TODO: add placeholders
+              return <div className={"h-20"} key={key} />
+            })}
           {messages.map((messageId) => (
             <Message key={messageId} id={messageId} />
           ))}

--- a/frontend/src/components/chats/MessagesDateGroups.tsx
+++ b/frontend/src/components/chats/MessagesDateGroups.tsx
@@ -6,6 +6,7 @@ import Message from "@/components/chats/Message"
 
 const MessagesDateGroups: FC<{ messageIds: number[]; showStickyDate: boolean }> = ({
   messageIds,
+  showStickyDate,
 }) => {
   const { messages } = useMessages(messageIds)
 
@@ -31,11 +32,17 @@ const MessagesDateGroups: FC<{ messageIds: number[]; showStickyDate: boolean }> 
 
   return (
     <>
+      {processingMessages.map((_, key) => {
+        // TODO: add placeholders
+        return <div className={"h-20"} key={key} />
+      })}
       {groups.map(([date, messages], key) => (
         <div key={date} className={"relative flex flex-col gap-1.5 items-center"}>
           <div
             className={
-              "sticky top-1 text-base-content bg-base bg-opacity-80 backdrop-blur px-2 rounded-xl"
+              "pt-1 text-base-content bg-base bg-opacity-80 backdrop-blur px-2 rounded-xl" +
+              " " +
+              (key === groups.length - 1 && !showStickyDate ? "" : "sticky top-0")
             }
           >
             {formatDate(date)}

--- a/frontend/src/components/chats/MessagesDateGroups.tsx
+++ b/frontend/src/components/chats/MessagesDateGroups.tsx
@@ -8,15 +8,10 @@ const MessagesDateGroups: FC<{ messageIds: number[]; showStickyDate: boolean }> 
   messageIds,
   showStickyDate,
 }) => {
-  // load the most recent messages first
-  messageIds.reverse()
-
-  const { messages } = useMessages(messageIds)
-
-  // reverse back to original order
-  messages.reverse()
+  const { messages: reversedMessages } = useMessages(messageIds.slice().reverse())
 
   const { groupedMessages, processingMessages } = useMemo(() => {
+    const messages = reversedMessages.slice().reverse()
     const groupedMessages = messages.reduce((acc, message) => {
       if (!message) {
         return acc
@@ -32,7 +27,7 @@ const MessagesDateGroups: FC<{ messageIds: number[]; showStickyDate: boolean }> 
     const processingMessages = messages.filter((message) => !message)
 
     return { groupedMessages, processingMessages }
-  }, [messages])
+  }, [reversedMessages])
 
   const groups = Object.entries(groupedMessages)
 

--- a/frontend/src/components/chats/WriteMessageForm.tsx
+++ b/frontend/src/components/chats/WriteMessageForm.tsx
@@ -29,6 +29,7 @@ const WriteMessageForm: FC<{
         onChange={(e) => setInput(e.currentTarget.value)}
         onBlur={() => setInput(input.trim())}
         value={input}
+        maxRows={5}
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault()

--- a/frontend/src/components/markdown/markdown.tsx
+++ b/frontend/src/components/markdown/markdown.tsx
@@ -1,16 +1,12 @@
 "use client"
 
-import { FC, useEffect, useState } from "react"
+import { FC, memo, useEffect, useState } from "react"
 
 import "highlight.js/styles/github-dark.css"
 
 import RenderMarkdown from "@/components/markdown/render"
 
-const Markdown: FC<{ content: string; className?: string; fallback?: string }> = ({
-  content,
-  className = "",
-  fallback = "",
-}) => {
+const Markdown: FC<{ content: string; className?: string; fallback?: string }> = ({ content }) => {
   const [html, setHtml] = useState<string>()
 
   useEffect(() => {
@@ -19,16 +15,16 @@ const Markdown: FC<{ content: string; className?: string; fallback?: string }> =
     })
   }, [content, html])
 
-  if (html === undefined) {
-    return <div className={className}>{fallback}</div>
+  if (!html) {
+    return null
   }
 
   return (
     <div
-      className={"prose dark:prose-invert max-w-full" + " " + className}
+      className={"prose dark:prose-invert max-w-full"}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   )
 }
 
-export default Markdown
+export default memo(Markdown)


### PR DESCRIPTION
This pull request improves chat lazy loading that was added in #78 and fixes performance issues with scrolling.

- Performance of `<Message />` component is now improved. There're much less re-renders now.

- Scrolling event performance is now better, the problem with lags when scrolling several hundreds short messages is fixed. The throttle event now called with delay `500`, which makes it harder to spam scroll events even on low-end devices. 

- Scroll to bottom is improved. The old `setTimout` implementation was unstable for big amount of messages. It is now replaced with faster [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver), which is a new feature of JavaScript with good browser support (chrome 2018, safari 2020). 

- Dates are now hidden automatically and shown on scroll. Just like in other messengers.
