### PR TITLE
Fix bug with no syntax highlighting in chats

### DIFF
--- a/frontend/src/components/chats/Message.tsx
+++ b/frontend/src/components/chats/Message.tsx
@@ -6,6 +6,8 @@ import { useMessage } from "@/api/chats/messages"
 import RenderMarkdown from "@/components/markdown/render"
 import { Message as MessageType } from "@/ws"
 
+import "highlight.js/styles/github-dark.css"
+
 const Message: FC<{ id: number }> = ({ id }) => {
   const { message } = useMessage(id)
 

--- a/frontend/src/components/markdown/render.ts
+++ b/frontend/src/components/markdown/render.ts
@@ -39,7 +39,7 @@ export function MarkdownToPlain<
   }
 
   const codeHandler: Handler = (node) => {
-    return { type: "code", value: `[code in ${node.lang}]` }
+    return { type: "code", value: node.lang ? `[code in ${node.lang}]` : "[code]" }
   }
 
   const processor = remark().use(stripMarkdown, {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -59,18 +59,17 @@ body {
   }
 
   /* Inline code */
-  .prose code:not(.prose pre code):before,
-  .prose code:not(.prose pre code):after {
-    content: none;
-  }
-
   .prose code:not(.prose pre code) {
     @apply bg-gray-200 dark:bg-gray-800 p-1 px-2 rounded;
   }
 
   /* Code block */
-  .prose pre:has(code) {
-    @apply p-0 rounded;
+  .prose pre:has(code.hljs) {
+    @apply p-0;
+  }
+
+  .prose pre:has(code:not(.hljs)) {
+    @apply bg-gray-200 dark:bg-gray-800;
   }
 
   @layer components {


### PR DESCRIPTION
In #82 the `<Markdown />` component was replaced by custom `<MessageMarkdown />` to show messages only after rendering markdown.

But the CSS file for syntax highlighting was not imported, which caused syntax highlighting not working in chats. 

![image](https://github.com/merpw/forum/assets/43277901/31146d83-85d3-41ef-9633-2c1ea7050947)


This pull request imports this css file and fixes this bug as well as fixes problems with plain text code blocks like this:

```markdown
    ```
    This is just a plain text without a specified language
    ```
```

So now they look like this:

![image](https://github.com/merpw/forum/assets/43277901/fe3e754c-2f73-441c-bd5e-eff0f2fc9631)
