### PR TITLE
Add attachments service to CI

### DIFF
--- a/.github/workflows/backend-docker-image.yml
+++ b/.github/workflows/backend-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: ["forum", "chat"]
+        service: ["forum", "chat", "attachments"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/backend/attachments/README.md
+++ b/backend/attachments/README.md
@@ -1,0 +1,23 @@
+# backend/attachments
+
+Image uploading service.
+
+---
+
+## Usage
+
+### Run `go run backend/attachments [PARAMS]` to start API server
+
+_**Example:** `go run .` to run on default port 8082_
+
+### Params:
+
+- `--port` - port to run API server on (default: 8081)
+- `--dir` - directory to store uploaded files (default: `./attachments`)
+
+### Environment variables:
+
+- `AUTH_BASE_URL` - optional, default http://localhost:8080 - base url to the auth service
+
+- `FORUM_BACKEND_SECRET` - optional, secret header `Internal-Auth` value to access `/internal/` routes of the Auth
+  service

--- a/docker-compose.tag.yml
+++ b/docker-compose.tag.yml
@@ -4,5 +4,7 @@ services:
     image: ghcr.io/merpw/forum/backend-forum:${FORUM_TAG-main}
   backend-chat:
     image: ghcr.io/merpw/forum/backend-chat:${CHAT_TAG-main}
+  backend-attachments:
+    image: ghcr.io/merpw/forum/backend-attachments:${ATTACHMENTS_TAG-main}
   frontend:
     image: ghcr.io/merpw/forum/frontend:${FRONTEND_TAG-main}

--- a/start.sh
+++ b/start.sh
@@ -8,7 +8,9 @@ else
   export TAG=$1
 fi;
 
-export FORUM_BACKEND_SECRET=$(openssl rand -hex 32)
+FORUM_BACKEND_SECRET=$(openssl rand -hex 32)
+
+export FORUM_BACKEND_SECRET=$FORUM_BACKEND_SECRET
 
 if [ "$TAG" == "latest" ]; then
     echo "Starting latest revision"
@@ -36,16 +38,21 @@ if [ -z "$CHAT_TAG" ]; then
     export CHAT_TAG=$TAG
 fi;
 
+if [ -z "$ATTACHMENTS_TAG" ]; then
+    export ATTACHMENTS_TAG=$TAG
+fi;
+
 if [ -z "$FRONTEND_TAG" ]; then
     export FRONTEND_TAG=$TAG
 fi;
+
 
 echo "Pulling images forum-backend:$FORUM_TAG, chat-backend:$CHAT_TAG, frontend:$FRONTEND_TAG..."
 
 # Fallback images to main if tag is not found
 
 PULL_RESULT=$(docker compose -f docker-compose.yml -f docker-compose.tag.yml pull 2>&1 | tee /dev/tty \
-| grep "Warning" | grep -Eo "backend-forum|backend-chat|frontend" )
+| grep "Warning" | grep -Eo "backend-forum|backend-chat|backend-attachments|frontend" )
 
 while read -r line ; do
     if [ "$line" == "backend-forum" ]; then
@@ -54,11 +61,14 @@ while read -r line ; do
     if [ "$line" == "backend-chat" ]; then
       export CHAT_TAG=main
     fi;
+    if [ "$line" == "backend-attachments" ]; then
+      export ATTACHMENTS_TAG=main
+    fi;
     if [ "$line" == "frontend" ]; then
       export FRONTEND_TAG=main
     fi;
 done <<< "$PULL_RESULT"
 
-echo "Starting forum-backend:$FORUM_TAG, chat-backend:$CHAT_TAG, frontend:$FRONTEND_TAG..."
+echo "Starting backend-forum:$FORUM_TAG, backend-chat:$CHAT_TAG, backend-attachments:$ATTACHMENTS_TAG, frontend:$FRONTEND_TAG..."
 
 docker-compose -f docker-compose.yml -f docker-compose.tag.yml up;


### PR DESCRIPTION
In the recent #105 we've added a new microservice. It work great locally, but while deployment I found that the new `attachments` service was not added to GitHub workflows. 

This PR adds this service to CI and adds a simple README for the new service to trigger backend workflow. 

I've tested it in a private repo, it works as expected.