### PR TITLE
Fix bug with broken private chats

### DIFF
--- a/backend/chat/database/ops_create_chat.go
+++ b/backend/chat/database/ops_create_chat.go
@@ -3,7 +3,7 @@ package database
 const CreateChatMessage = "Chat created"
 
 // CreatePrivateChat creates a new user-user chat, adds members and sends a system message about it.
-func (db DB) CreatePrivateChat(creatorId, companionId int) (chatId int) {
+func (db DB) CreatePrivateChat(creatorId, userId int) (chatId int) {
 	r, err := db.Exec("INSERT INTO chats DEFAULT VALUES")
 	if err != nil {
 		panic(err)
@@ -17,7 +17,7 @@ func (db DB) CreatePrivateChat(creatorId, companionId int) (chatId int) {
 		INSERT INTO memberships (chat_id, user_id) VALUES (?, ?);
 		INSERT INTO memberships (chat_id, user_id) VALUES (?, ?);`,
 		id, creatorId,
-		id, companionId)
+		id, userId)
 	if err != nil {
 		panic(err)
 	}

--- a/backend/chat/handlers/chat_id.go
+++ b/backend/chat/handlers/chat_id.go
@@ -9,7 +9,7 @@ import (
 
 type chatIdResponseData struct {
 	Id            int  `json:"id"`
-	CompanionId   *int `json:"companionId,omitempty"`
+	CompanionId   *int `json:"userId,omitempty"`
 	GroupId       *int `json:"groupId,omitempty"`
 	LastMessageId int  `json:"lastMessageId"`
 }

--- a/backend/chat/handlers/users_id.go
+++ b/backend/chat/handlers/users_id.go
@@ -8,16 +8,16 @@ import (
 )
 
 func (h *Handlers) usersIdChat(message ws.Message, client *ws.Client) {
-	companionIdStr := strings.Split(message.Item.URL, "/")[2]
+	userIdStr := strings.Split(message.Item.URL, "/")[2]
 	// "/users/1/chat" -> "1"
 
-	companionId, err := strconv.Atoi(companionIdStr)
+	userId, err := strconv.Atoi(userIdStr)
 	if err != nil {
 		log.Println(err)
 		return
 	}
 
-	chatId := h.DB.GetPrivateChat(client.UserId, companionId)
+	chatId := h.DB.GetPrivateChat(client.UserId, userId)
 	responseMessage := ws.BuildResponseMessage(message, chatId)
 
 	h.Hub.Broadcast(responseMessage, client.UserId)

--- a/frontend/src/api/chats/chats.ts
+++ b/frontend/src/api/chats/chats.ts
@@ -29,7 +29,7 @@ export const useChat = (id: number) => {
   return { chat }
 }
 
-type AssociationData = { companionId: number } | { groupId: number }
+type AssociationData = { userId: number } | { groupId: number }
 
 export const useCreateChat = () => {
   const dispatch = useAppDispatch()
@@ -40,10 +40,10 @@ export const useCreateChat = () => {
 }
 
 export const useAssociatedChat = (association: AssociationData) => {
-  const isUser = "companionId" in association
+  const isUser = "userId" in association
   const chatId = useAppSelector((state) =>
     isUser
-      ? state.chats.userChats?.[association.companionId]
+      ? state.chats.userChats?.[association.userId]
       : state.chats.groupChats?.[association.groupId]
   )
   const dispatch = useAppDispatch()
@@ -52,7 +52,7 @@ export const useAssociatedChat = (association: AssociationData) => {
     if (!chatId) {
       dispatch(
         wsActions.sendGet(
-          isUser ? `/users/${association.companionId}/chat` : `/groups/${association.groupId}/chat`
+          isUser ? `/users/${association.userId}/chat` : `/groups/${association.groupId}/chat`
         )
       )
     }

--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -61,7 +61,7 @@ const Page = async ({ params }: Props) => {
     try {
       const userId = +params.id.slice(1)
       const companion = await getUserLocal(userId)
-      return <AssociatedIdChatPage companionId={companion.id} />
+      return <AssociatedIdChatPage userId={companion.id} />
     } catch (error) {
       return redirect("/chat")
     }

--- a/frontend/src/components/chats/ChatInfo.tsx
+++ b/frontend/src/components/chats/ChatInfo.tsx
@@ -7,11 +7,11 @@ import { useUser } from "@/api/users/hooks"
 import { useGroup } from "@/api/groups/hooks"
 import GroupAvatar from "@/components/groups/Avatar"
 
-const ChatInfo: FC<{ groupId: number } | { companionId: number }> = (props) => {
+const ChatInfo: FC<{ groupId: number } | { userId: number }> = (props) => {
   if ("groupId" in props) {
     return <GroupChatInfo groupId={props.groupId} />
   }
-  return <UserChatInfo userId={props.companionId} />
+  return <UserChatInfo userId={props.userId} />
 }
 
 const UserChatInfo: FC<{ userId: number }> = ({ userId }) => {

--- a/frontend/src/components/chats/page/AssociatedIdChatPage.tsx
+++ b/frontend/src/components/chats/page/AssociatedIdChatPage.tsx
@@ -8,7 +8,7 @@ import ChatInfo from "@/components/chats/ChatInfo"
 import WriteMessageForm from "@/components/chats/WriteMessageForm"
 import ChatIdPage from "@/components/chats/page/ChatIdPage"
 
-export const AssociatedIdChatPage: FC<{ companionId: number } | { groupId: number }> = (props) => {
+export const AssociatedIdChatPage: FC<{ userId: number } | { groupId: number }> = (props) => {
   const { chatId } = useAssociatedChat(props)
 
   const [firstMessage, setFirstMessage] = useState<string | null>(null)

--- a/frontend/src/components/chats/section/ChatList.tsx
+++ b/frontend/src/components/chats/section/ChatList.tsx
@@ -66,7 +66,7 @@ const ChatCard: FC<{ chatId: number }> = ({ chatId }) => {
           (unreadMessagesCount > 0 ? "ring-2 ring-secondary" : "")
         }
       >
-        {"companionId" in chat && <CompanionAvatarWrapper userId={chat.companionId} />}
+        {"userId" in chat && <CompanionAvatarWrapper userId={chat.userId} />}
         {"groupId" in chat && <GroupAvatarWrapper groupId={chat.groupId} />}
         {unreadMessagesCount > 0 && (
           <div className={"absolute badge badge-secondary top-3 right-3 font-bold py-3"}>
@@ -74,7 +74,7 @@ const ChatCard: FC<{ chatId: number }> = ({ chatId }) => {
           </div>
         )}
         <div className={"w-full"}>
-          {"companionId" in chat && <CompanionData userId={chat.companionId} />}
+          {"userId" in chat && <CompanionData userId={chat.userId} />}
           {"groupId" in chat && <GroupData groupId={chat.groupId} />}
           {typingData ? (
             <div className={"flex items-center gap-1 mb-5 text-sm"}>

--- a/frontend/src/store/chats/index.ts
+++ b/frontend/src/store/chats/index.ts
@@ -56,8 +56,8 @@ const chatSlice = createSlice({
       reducer: (state, action: PayloadAction<{ chatId: number; data: Chat | null }>) => {
         state.chats[action.payload.chatId] = action.payload.data
         if (action.payload.data) {
-          if ("companionId" in action.payload.data) {
-            state.userChats[action.payload.data.companionId] = action.payload.chatId
+          if ("userId" in action.payload.data) {
+            state.userChats[action.payload.data.userId] = action.payload.chatId
           } else if ("groupId" in action.payload.data) {
             state.groupChats[action.payload.data.groupId] = action.payload.chatId
           }

--- a/frontend/src/ws.ts
+++ b/frontend/src/ws.ts
@@ -12,7 +12,7 @@ export type Chat = {
   lastMessageId: number
 } & (
   | {
-      companionId: number
+      userId: number
     }
   | {
       groupId: number


### PR DESCRIPTION
In the recent #113 we added group chats. 

To support group chats, the chat creation functionality was updated. But while updating the `userId` field was accidently renamed to `companionId` in several places. This happened because we had different name of the field on frontend and backend. 

This PR renames `companionId` back to `userId` everywhere for consistency. 

This bug caused serious problems when creating private chats (sending `companionId` instead of `userId` in the `chat/create` request). Looks like we missed this during testing and reviewing 😢

Now it should be fixed:

https://maximihajlov-laughing-zebra-qp7q57wg4v5c65g9-80.app.github.dev


https://github.com/merpw/forum/assets/43277901/9b70a0fd-c247-4d3e-a20a-b0c5703b953a

